### PR TITLE
Fix for Linux v6.7

### DIFF
--- a/usr/src/AIC8800/drivers/aic8800/aic8800_fdrv/rwnx_cfgfile.h
+++ b/usr/src/AIC8800/drivers/aic8800/aic8800_fdrv/rwnx_cfgfile.h
@@ -11,6 +11,8 @@
 #ifndef _RWNX_CFGFILE_H_
 #define _RWNX_CFGFILE_H_
 
+#include "lmac_msg.h"
+#include <linux/if_ether.h>
 /*
  * Structure used to retrieve information from the Config file used at Initialization time
  */

--- a/usr/src/AIC8800/drivers/aic8800/aic8800_fdrv/rwnx_defs.h
+++ b/usr/src/AIC8800/drivers/aic8800/aic8800_fdrv/rwnx_defs.h
@@ -337,6 +337,9 @@ enum rwnx_ap_flags {
  *
  */
 struct rwnx_vif {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0)
+    struct mutex wdev_mutex;
+#endif
     struct list_head list;
     struct rwnx_hw *rwnx_hw;
     struct wireless_dev wdev;


### PR DESCRIPTION
Adapt to new changes of cfg80211 subsystem header files since Linux v6.7
Tested on Ubuntu 24.04.1 LTS (Linux 6.8.0-49-generic)